### PR TITLE
Extend PythonTube command line options

### DIFF
--- a/PythonTube/FluidSolver.py
+++ b/PythonTube/FluidSolver.py
@@ -19,9 +19,9 @@ from precice import *
 
 parser = argparse.ArgumentParser()
 parser.add_argument("configurationFileName", help="Name of the xml precice configuration file.", nargs='?', type=str, default="precice-config.xml")
-parser.add_argument("--write_vtk", help="Save vtk files of each timestep in the 'VTK' folder.", action='store_true')
-parser.add_argument("--enable_plot", help="Show a continuously updated plot of the tube while simulating.", action='store_true')
-parser.add_argument("--write_video", help="Save a video of the simulation as 'writer_test.mp4'. \
+parser.add_argument("--write-vtk", help="Save vtk files of each timestep in the 'VTK' folder.", action='store_true')
+parser.add_argument("--enable-plot", help="Show a continuously updated plot of the tube while simulating.", action='store_true')
+parser.add_argument("--write-video", help="Save a video of the simulation as 'writer_test.mp4'. \
                     NOTE: This requires 'enable_plot' to be active!", action='store_true')
 
 try:
@@ -37,7 +37,7 @@ plotting_mode = config.PlottingModes.VIDEO if args.enable_plot else config.Plott
 if args.write_video and not args.enable_plot:
     print("")
     print("To create a video it is required to enable plotting for this run.")
-    print("Please supply both the '--enable_plot' and '--write_video' flags.")
+    print("Please supply both the '--enable-plot' and '--write-video' flags.")
     quit()
 writeVideoToFile = True if args.write_video else False
 

--- a/PythonTube/FluidSolver.py
+++ b/PythonTube/FluidSolver.py
@@ -71,7 +71,7 @@ if plotting_mode == config.PlottingModes.VIDEO:
     fig, ax = plt.subplots(1)
     if writeVideoToFile:
         FFMpegWriter = manimation.writers['imagemagick']
-        metadata = dict(title='PuleTube')
+        metadata = dict(title='PulseTube')
         writer = FFMpegWriter(fps=15, metadata=metadata)
         writer.setup(fig, "writer_test.mp4", 100)
 

--- a/PythonTube/StructureSolver.py
+++ b/PythonTube/StructureSolver.py
@@ -6,21 +6,21 @@ import argparse
 from mpi4py import MPI
 import numpy as np
 import configuration_file as config
- 
+
 import precice
 from precice import *
 
 print("Starting Structure Solver...")
 
 parser = argparse.ArgumentParser()
-parser.add_argument("configurationFileName", help="Name of the xml config file.", type=str)
+parser.add_argument("configurationFileName", help="Name of the xml config file.", nargs='?', type=str, default="precice-config.xml")
 
 try:
     args = parser.parse_args()
 except SystemExit:
     print("")
     print("Did you forget adding the precice configuration file as an argument?")
-    print("Try $python StructureSolver.py precice-config.xml")
+    print("Try '$ python StructureSolver.py precice-config.xml'")
     quit()
 
 configFileName = args.configurationFileName
@@ -88,4 +88,3 @@ while interface.is_coupling_ongoing():
 print("Exiting StructureSolver")
 
 interface.finalize()
-


### PR DESCRIPTION
This PR adds default run cases and more launch options.

Executing the FluidSolver.py and StructureSolver.py scripts without
further command line arguments will now attempt to launch with
the `precice-config.xml` configuration file by default.

New argument flags:
- `--write_vtk` store VTK files for this run. Sets `OutputModes` to VTK.
- `--enable_plot` show live plot of simulation. Sets `PlottingModes` to VIDEO.
- `--write_video` store a mp4 of the plot. Sets `writeVideoToFile` to True. Requires `enable_plot` to be set.

As video writing is only available when `PlottingModes` is set to VIDEO, also checks that the `write_video` argument is set only when `enable_plot` is set as well.