### PR TITLE
Update README in accordance with structure overhaul

### DIFF
--- a/PythonTube/README.md
+++ b/PythonTube/README.md
@@ -1,1 +1,0 @@
-Here the 1D elastic tube example is realized using the Python API of preCICE. Refer to the [preCICE wiki](https://github.com/precice/precice/wiki/1D-elastic-tube-using-the-Python-API) for more information on this example.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This tutorial comes in two distinct versions, one written in C++ and one in Python. The code for each are located in the folders `cxx` and `python` respectively.
 
-Choose a version, then navigate down to the corresponding sections for [Python](#python-version) and [C++](#c++-version) instructions.
+Choose a version, then navigate down to the corresponding sections for [Python](#python-version) and [C++](#c-version) instructions.
 
 ---
 ## Python version
@@ -17,7 +17,7 @@ This version is realized using the Python API for preCICE. Check [this entry in 
 
 - [preCICE Python Bindings](https://github.com/precice/precice/blob/develop/src/precice/bindings/python/README.md).
 
-**Note:** these requirements are specific to the Python variant of the code. If you wish to run the C++ version, you require different packages (see [this section](#c++-version)).
+**Note:** these requirements are specific to the Python variant of the code. If you wish to run the C++ version, you require different packages (see [this section](#c-version)).
 
 ### How to run
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ This version is realized using the Python API for preCICE. Check [this entry in 
     ```bash
     $ ./Allclean
     ```
+    
+**Optional:** Visualization and video output can be triggered via the options `--enable-plot` and `--write-video` of `FluidSolver.py`. If you want to use `Allrun`, you can set these options via environment variables:
+
+* `$ ENABLE_PLOT=1 ./Allrun`: plots the simulation over time
+* `$ ENABLE_PLOT=1 WRITE_VIDEO=1 ./Allrun`: plots the simulation over time and creates a video.
 
 ---
 ## C++ version

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Check [this preCICE wiki page](https://github.com/precice/precice/wiki/Example-f
   ```bash
   $ cd cxx/ && cmake .
   ```
-  *Note* if `cmake` cannot find `libprecice.so`, please make sure that you are [linking to preCICE correctly](https://github.com/precice/precice/wiki/Linking-to-preCICE#linking-from-cmake).
+  **Note:** if `cmake` cannot find `libprecice.so`, please make sure that you are [linking to preCICE correctly](https://github.com/precice/precice/wiki/Linking-to-preCICE#linking-from-cmake).
 
 2. Make the tutorial:
   ```bash

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Check [this preCICE wiki page](https://github.com/precice/precice/wiki/Example-f
   ```bash
   $ cd cxx/ && cmake .
   ```
+  *Note* if `cmake` cannot find `libprecice.so`, please make sure that you are [linking to preCICE correctly](https://github.com/precice/precice/wiki/Linking-to-preCICE#linking-from-cmake).
 
 2. Make the tutorial:
   ```bash

--- a/README.md
+++ b/README.md
@@ -1,12 +1,102 @@
 # preCICE example for FSI: 1D elastic tube
 
-For more information see [1]. Scenario taken from [2].
+## First Step: Choose a version
 
-**The quick path:** For building and running instructions refer to [this preCICE wiki page](https://github.com/precice/precice/wiki/Running-the-1D-elastic-tube-example).
+This tutorial comes in two distinct versions, one written in C++ and one in Python. The code for each are located in the folders `cxx` and `python` respectively.
 
-**The detailed path:** If you prefer, a tutorial can take you step by step through this case. See [this preCICE wiki page](https://github.com/precice/precice/wiki/Example-for-FSI:-1D-elastic-tube).
+Choose a version, then navigate down to the corresponding sections for [Python](#python-version) and [C++](#c++-version) instructions.
+
+---
+## Python version
+
+This version is realized using the Python API for preCICE. Check [this entry in the preCICE wiki](https://github.com/precice/precice/wiki/1D-elastic-tube-using-the-Python-API) for more information on this example.
+
+### Requirements
+
+- [preCICE](https://github.com/precice/precice/wiki/Get-preCICE)
+
+- [preCICE Python Bindings](https://github.com/precice/precice/blob/develop/src/precice/bindings/python/README.md).
+
+**Note:** these requirements are specific to the Python variant of the code. If you wish to run the C++ version, you require different packages (see [this section](#c++-version)).
+
+### How to run
+
+0. Clone this repository:
+    ```bash
+    $ git clone https://github.com/precice/elastictube1d.git
+    ```
+
+1. Navigate into the `python` directory and execute the `Allrun` script to run both solver participants directly:
+    ```bash
+    $ cd python/ && ./Allrun
+    ```
+
+2. After the script exits, you can view the output `.vtk` files in the `VTK` folder located in the root directory.
+
+3. To clean up the log files and vtk files created during a run, execute the `Allclean` script.
+    ```bash
+    $ ./Allclean
+    ```
+
+---
+## C++ version
+
+Check [this preCICE wiki page](https://github.com/precice/precice/wiki/Example-for-FSI:-1D-elastic-tube) for a detailed description of this tutorial. For more information see [1]. Elastictube scenario taken from [2].
+
+### Requirements
+
+- [preCICE](https://github.com/precice/precice/wiki/Get-preCICE)
+
+- [LAPACK](http://performance.netlib.org/lapack/#_lapack_version_3_8_0_2). On Ubuntu-like Linux distributions, you can also install via executing:
+  ```bash
+  $ sudo apt-get install liblapack-dev
+  ```
+
+### How to run
+
+0. Clone this repository:
+    ```bash
+    $ git clone https://github.com/precice/elastictube1d.git
+    ```
+
+1. Navigate into the `cxx` directory and build the Makefiles:
+  ```bash
+  $ cd cxx/ && cmake .
+  ```
+
+2. Make the tutorial:
+  ```bash
+  $ make all
+  ```
+
+3. After successful compilation, you can now launch preset configuration by calling the `Allrun` script located in the current folder:
+  ```bash
+  $ ./Allrun
+  ```
+  Results will be stored as .vtk files in the `cxx/Postproc` folder.
+
+  **Optional:** You can visualize the results with the `Postproc/fluid.py` script:
+  ```bash
+  $ python Postproc/fluid.py <quantity> Postproc/<prefix>
+  ```
+  Note the required arguments specifying which quantity to plot (`pressure`, `velocity` or `diameter`) and a name prefix for the target vtk files.
+  For example, to plot the diameter using the default prefix for vtk files, we execute:
+  ```bash
+  $ python Postproc/fluid.py diameter Postproc/out_fluid_
+  ```
+  An image of this diameter plot can be found in the `cxx/example` folder.
+
+  **Alternative:**: If you wish to run the parallel versions of each solver, run the `Allrun_parallel` script instead. Note that no vtk output is generated for this solver configuration!
+
+5. To quickly clean the folder of log files and results from previous runs, execute `Allclean`:
+  ```bash
+  $ ./Allclean
+  ```
 
 
+**Note:** The tutorial can also be run manually by launching both participants by hand. See [this preCICE wiki page](https://github.com/precice/precice/wiki/Running-the-1D-elastic-tube-example) for instructions.
+
+---
 ## References
 
 [1] M. Mehl, B. Uekermann, H. Bijl, D. Blom, B. Gatzhammer, and A. van Zuijlen.


### PR DESCRIPTION
## Revision of the README files to conform with the updated tutorial structure from #16

- Update and extend main README file to describe the new repository structure and
provide instructions on how to run the tutorials with bash scripts `Allrun` and `Allclean`

- Removed README that was specific to the Python version. The main README file includes a reference to the relevant wiki entry instead.
