### PR TITLE
Update PythonTube to use new python-bindings

### DIFF
--- a/python/Allclean
+++ b/python/Allclean
@@ -3,6 +3,8 @@
 
 echo "Cleaning logs and output files from previous runs..."
 
+rm -r precice-run/
+
 rm -f precice-FLUID-events.json \
       precice-STRUCTURE-events.json \
       precice-FLUID-iterations.log \

--- a/python/FluidSolver.py
+++ b/python/FluidSolver.py
@@ -88,6 +88,7 @@ vertexIDs = interface.set_mesh_vertices(meshID, grid)
 t = 0
 
 print("Fluid: init precice...")
+# preCICE defines timestep size of solver via precice-config.xml
 precice_dt = interface.initialize()
 
 if interface.is_action_required(action_write_initial_data()):
@@ -112,8 +113,7 @@ while interface.is_coupling_ongoing():
     velocity, pressure, success = perform_partitioned_implicit_euler_step(velocity_n, pressure_n, crossSectionLength_n,
                                                                           crossSectionLength, dx, precice_dt, config.velocity_in(t + precice_dt), custom_coupling=False)
     interface.write_block_scalar_data(pressureID, vertexIDs, pressure)
-    dt = interface.advance(precice_dt)
-    precice_dt = min(precice_dt, dt)
+    precice_dt = interface.advance(precice_dt)
     crossSectionLength = interface.read_block_scalar_data(crossSectionLengthID, vertexIDs)
 
     if interface.is_action_required(action_read_iteration_checkpoint()): # i.e. not yet converged

--- a/python/FluidSolver.py
+++ b/python/FluidSolver.py
@@ -52,8 +52,7 @@ print("N: " + str(N))
 solverName = "FLUID"
 
 print("Configure preCICE...")
-interface = precice.Interface(solverName, 0, 1)
-interface.configure(configFileName)
+interface = precice.Interface(solverName, configFileName, 0, 1)
 print("preCICE configured...")
 
 dimensions = interface.get_dimensions()
@@ -79,12 +78,12 @@ crossSectionLengthID = interface.get_data_id("CrossSectionLength", meshID)
 pressureID = interface.get_data_id("Pressure", meshID)
 
 vertexIDs = np.zeros(N+1)
-grid = np.zeros([dimensions, N+1])
+grid = np.zeros([N+1, dimensions])
 
-grid[0,:] = np.linspace(0, config.L, N+1)  # x component
-grid[1,:] = 0  # y component, leave blank
+grid[:, 0] = np.linspace(0, config.L, N+1)  # x component
+grid[:, 1] = 0  # y component, leave blank
 
-interface.set_mesh_vertices(meshID, N+1, grid.flatten('F'), vertexIDs)
+vertexIDs = interface.set_mesh_vertices(meshID, grid)
 
 t = 0
 
@@ -92,13 +91,13 @@ print("Fluid: init precice...")
 precice_tau = interface.initialize()
 
 if interface.is_action_required(action_write_initial_data()):
-    interface.write_block_scalar_data(pressureID, N+1, vertexIDs, pressure)
+    interface.write_block_scalar_data(pressureID, vertexIDs, pressure)
     interface.fulfilled_action(action_write_initial_data())
 
 interface.initialize_data()
 
 if interface.is_read_data_available():
-    interface.read_block_scalar_data(crossSectionLengthID, N+1, vertexIDs, crossSectionLength)
+    interface.read_block_scalar_data(crossSectionLengthID, vertexIDs, crossSectionLength)
 
 crossSectionLength_n = np.copy(crossSectionLength)
 velocity_n = config.velocity_in(0) * crossSectionLength_n[0] * np.ones(N+1) / crossSectionLength_n  # initialize such that mass conservation is fulfilled
@@ -111,13 +110,13 @@ while interface.is_coupling_ongoing():
         interface.fulfilled_action(action_write_iteration_checkpoint())
 
     velocity, pressure, success = perform_partitioned_implicit_euler_step(velocity_n, pressure_n, crossSectionLength_n, crossSectionLength, dx, precice_tau, config.velocity_in(t + precice_tau), custom_coupling=False)
-    interface.write_block_scalar_data(pressureID, N+1, vertexIDs, pressure)
-    interface.advance(precice_tau)
-    interface.read_block_scalar_data(crossSectionLengthID, N+1, vertexIDs, crossSectionLength)
+    interface.write_block_scalar_data(pressureID, vertexIDs, pressure)
+    precice_tau = interface.advance(precice_tau)
+    interface.read_block_scalar_data(crossSectionLengthID, vertexIDs, crossSectionLength)
 
     if interface.is_action_required(action_read_iteration_checkpoint()): # i.e. not yet converged
         interface.fulfilled_action(action_read_iteration_checkpoint())
-    else: # converged, timestep complete
+    else:  # converged, timestep complete
         t += precice_tau
         if plotting_mode is config.PlottingModes.VIDEO:
             tubePlotting.doPlotting(ax, crossSectionLength_n, velocity_n, pressure_n, dx, t)

--- a/python/FluidSolver.py
+++ b/python/FluidSolver.py
@@ -97,7 +97,7 @@ if interface.is_action_required(action_write_initial_data()):
 interface.initialize_data()
 
 if interface.is_read_data_available():
-    interface.read_block_scalar_data(crossSectionLengthID, crossSectionLength)
+    crossSectionLength = interface.read_block_scalar_data(crossSectionLengthID, vertexIDs)
 
 crossSectionLength_n = np.copy(crossSectionLength)
 velocity_n = config.velocity_in(0) * crossSectionLength_n[0] * np.ones(N+1) / crossSectionLength_n  # initialize such that mass conservation is fulfilled
@@ -112,7 +112,7 @@ while interface.is_coupling_ongoing():
     velocity, pressure, success = perform_partitioned_implicit_euler_step(velocity_n, pressure_n, crossSectionLength_n, crossSectionLength, dx, precice_tau, config.velocity_in(t + precice_tau), custom_coupling=False)
     interface.write_block_scalar_data(pressureID, vertexIDs, pressure)
     precice_tau = interface.advance(precice_tau)
-    interface.read_block_scalar_data(crossSectionLengthID, crossSectionLength)
+    crossSectionLength = interface.read_block_scalar_data(crossSectionLengthID, vertexIDs)
 
     if interface.is_action_required(action_read_iteration_checkpoint()): # i.e. not yet converged
         interface.fulfilled_action(action_read_iteration_checkpoint())

--- a/python/FluidSolver.py
+++ b/python/FluidSolver.py
@@ -97,7 +97,7 @@ if interface.is_action_required(action_write_initial_data()):
 interface.initialize_data()
 
 if interface.is_read_data_available():
-    interface.read_block_scalar_data(crossSectionLengthID, vertexIDs, crossSectionLength)
+    interface.read_block_scalar_data(crossSectionLengthID, crossSectionLength)
 
 crossSectionLength_n = np.copy(crossSectionLength)
 velocity_n = config.velocity_in(0) * crossSectionLength_n[0] * np.ones(N+1) / crossSectionLength_n  # initialize such that mass conservation is fulfilled
@@ -112,7 +112,7 @@ while interface.is_coupling_ongoing():
     velocity, pressure, success = perform_partitioned_implicit_euler_step(velocity_n, pressure_n, crossSectionLength_n, crossSectionLength, dx, precice_tau, config.velocity_in(t + precice_tau), custom_coupling=False)
     interface.write_block_scalar_data(pressureID, vertexIDs, pressure)
     precice_tau = interface.advance(precice_tau)
-    interface.read_block_scalar_data(crossSectionLengthID, vertexIDs, crossSectionLength)
+    interface.read_block_scalar_data(crossSectionLengthID, crossSectionLength)
 
     if interface.is_action_required(action_read_iteration_checkpoint()): # i.e. not yet converged
         interface.fulfilled_action(action_read_iteration_checkpoint())

--- a/python/StructureSolver.py
+++ b/python/StructureSolver.py
@@ -54,6 +54,7 @@ vertexIDs = interface.set_mesh_vertices(meshID, grid)
 t = 0
 
 print("Structure: init precice...")
+# preCICE defines timestep size of solver via precice-config.xml
 precice_dt = interface.initialize()
 
 if interface.is_action_required(action_write_initial_data()):
@@ -77,8 +78,7 @@ while interface.is_coupling_ongoing():
                 (pressure0 - 2.0 * config.c_mk ** 2) ** 2 / (pressure - 2.0 * config.c_mk ** 2) ** 2)
 
     interface.write_block_scalar_data(crossSectionLengthID, vertexIDs, crossSectionLength)
-    dt = interface.advance(precice_dt)
-    precice_dt = min(precice_dt, dt)
+    precice_dt = interface.advance(precice_dt)
     pressure = interface.read_block_scalar_data(pressureID, vertexIDs)
 
     if interface.is_action_required(action_read_iteration_checkpoint()):  # i.e. not yet converged

--- a/python/StructureSolver.py
+++ b/python/StructureSolver.py
@@ -30,8 +30,7 @@ print("N: " + str(N))
 solverName = "STRUCTURE"
 
 print("Configure preCICE...")
-interface = precice.Interface(solverName, 0, 1)
-interface.configure(configFileName)
+interface = precice.Interface(solverName, configFileName, 0, 1)
 print("preCICE configured...")
 
 dimensions = interface.get_dimensions()
@@ -44,12 +43,12 @@ crossSectionLengthID = interface.get_data_id("CrossSectionLength", meshID)
 pressureID = interface.get_data_id("Pressure", meshID)
 
 vertexIDs = np.zeros(N+1)
-grid = np.zeros([dimensions, N+1])
+grid = np.zeros([N+1, dimensions])
 
-grid[0,:] = np.linspace(0, config.L, N+1)  # x component
-#grid[1,:] = np.linspace(0, config.L, N+1)  # y component, leave blank
+grid[:, 0] = np.linspace(0, config.L, N+1)  # x component
+grid[:, 1] = 0 #np.linspace(0, config.L, N+1)  # y component, leave blank
 
-interface.set_mesh_vertices(meshID, N+1, grid.flatten('F'), vertexIDs)
+vertexIDs = interface.set_mesh_vertices(meshID, grid)
 
 t = 0
 
@@ -57,13 +56,13 @@ print("Structure: init precice...")
 precice_tau = interface.initialize()
 
 if (interface.is_action_required(action_write_initial_data())):
-   interface.write_block_scalar_data(crossSectionLengthID, N+1, vertexIDs, crossSectionLength)
+   interface.write_block_scalar_data(crossSectionLengthID, vertexIDs, crossSectionLength)
    interface.fulfilled_action(action_write_initial_data())
 
 interface.initialize_data()
 
 if (interface.is_read_data_available()):
-   interface.read_block_scalar_data(pressureID, N+1, vertexIDs, pressure)
+   interface.read_block_scalar_data(pressureID, vertexIDs, pressure)
 
 crossSection0 = config.crossSection0(pressure.shape[0] - 1)
 pressure0 = config.p0 * np.ones_like(pressure)
@@ -75,9 +74,9 @@ while interface.is_coupling_ongoing():
 
     crossSectionLength = crossSection0 * ((pressure0 - 2.0 * config.c_mk ** 2) ** 2 / (pressure - 2.0 * config.c_mk ** 2) ** 2)
 
-    interface.write_block_scalar_data(crossSectionLengthID, N + 1, vertexIDs, crossSectionLength)
-    interface.advance(precice_tau)
-    interface.read_block_scalar_data(pressureID, N + 1, vertexIDs, pressure)
+    interface.write_block_scalar_data(crossSectionLengthID, vertexIDs, crossSectionLength)
+    precice_tau = interface.advance(precice_tau)
+    interface.read_block_scalar_data(pressureID, vertexIDs, pressure)
 
     if interface.is_action_required(action_read_iteration_checkpoint()): # i.e. not yet converged
         interface.fulfilled_action(action_read_iteration_checkpoint())

--- a/python/StructureSolver.py
+++ b/python/StructureSolver.py
@@ -54,7 +54,7 @@ vertexIDs = interface.set_mesh_vertices(meshID, grid)
 t = 0
 
 print("Structure: init precice...")
-precice_tau = interface.initialize()
+precice_dt = interface.initialize()
 
 if interface.is_action_required(action_write_initial_data()):
     interface.write_block_scalar_data(crossSectionLengthID, vertexIDs, crossSectionLength)
@@ -77,13 +77,14 @@ while interface.is_coupling_ongoing():
                 (pressure0 - 2.0 * config.c_mk ** 2) ** 2 / (pressure - 2.0 * config.c_mk ** 2) ** 2)
 
     interface.write_block_scalar_data(crossSectionLengthID, vertexIDs, crossSectionLength)
-    precice_tau = interface.advance(precice_tau)
+    dt = interface.advance(precice_dt)
+    precice_dt = min(precice_dt, dt)
     pressure = interface.read_block_scalar_data(pressureID, vertexIDs)
 
     if interface.is_action_required(action_read_iteration_checkpoint()):  # i.e. not yet converged
         interface.fulfilled_action(action_read_iteration_checkpoint())
     else:
-        t += precice_tau
+        t += precice_dt
 
 print("Exiting StructureSolver")
 

--- a/python/StructureSolver.py
+++ b/python/StructureSolver.py
@@ -63,7 +63,7 @@ if interface.is_action_required(action_write_initial_data()):
 interface.initialize_data()
 
 if interface.is_read_data_available():
-    interface.read_block_scalar_data(pressureID, pressure)
+    pressure = interface.read_block_scalar_data(pressureID, vertexIDs)
 
 crossSection0 = config.crossSection0(pressure.shape[0] - 1)
 pressure0 = config.p0 * np.ones_like(pressure)
@@ -78,7 +78,7 @@ while interface.is_coupling_ongoing():
 
     interface.write_block_scalar_data(crossSectionLengthID, vertexIDs, crossSectionLength)
     precice_tau = interface.advance(precice_tau)
-    interface.read_block_scalar_data(pressureID, pressure)
+    pressure = interface.read_block_scalar_data(pressureID, vertexIDs)
 
     if interface.is_action_required(action_read_iteration_checkpoint()):  # i.e. not yet converged
         interface.fulfilled_action(action_read_iteration_checkpoint())

--- a/python/precice-config.xml
+++ b/python/precice-config.xml
@@ -45,16 +45,16 @@
     </participant>
 
     <!-- Communication method, use TCP sockets, Change network to "ib0" on SuperMUC -->
-    <m2n:sockets from="FLUID" to="STRUCTURE" network="lo"/>
+    <m2n:sockets from="FLUID" to="STRUCTURE"/>
 
       <coupling-scheme:serial-implicit>
          <participants first="FLUID" second="STRUCTURE"/>
          <max-time value="1"/>
          <timestep-length value=".01" valid-digits="8"/>
          <max-iterations value="100"/>
-         <exchange data="Pressure"      mesh="Structure_Nodes" from="FLUID" to="STRUCTURE" />
+         <exchange data="Pressure" mesh="Structure_Nodes" from="FLUID" to="STRUCTURE" />
          <exchange data="CrossSectionLength" mesh="Structure_Nodes" from="STRUCTURE" to="FLUID" initialize="true"/>
-         <relative-convergence-measure data="Pressure"        mesh="Structure_Nodes" limit="1e-5"/>
+         <relative-convergence-measure data="Pressure" mesh="Structure_Nodes" limit="1e-5"/>
          <relative-convergence-measure data="CrossSectionLength" mesh="Structure_Nodes" limit="1e-5"/>
          <extrapolation-order value="0"/>
          <acceleration:IQN-ILS>


### PR DESCRIPTION
This PR updates the `python` variant of the elastic tube 1d to use the new `python-bindings`. Closes https://github.com/precice/elastictube1d/issues/18 
This PR also completes the last python code related update to use the new `python-bindings` interface. Hence closes https://github.com/precice/precice/issues/432 